### PR TITLE
added a bug to the "bug tracker"

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
  - short versions of command-line flags, particularly `-f<flagname>`, are somewhat buggy.
  - maintaining a sandbox for multiple related packages is still laborious (as is necessary when builing large, multi-package projects).
  - *Fixed but not well tested* (only exercised with ghc7 on 32-bit debian, 6.10 and 6.12 are fairly well covered, though) -- GHC 7: `canonicalizePath` throws exceptions in recent versions of Directory, which is needed by ghc 7.  This causes `cabal-dev` to fail if the sandbox directory does not already exist.  One potential (but untested) workaround is to manually create the sandbox directory first, then run `cabal-dev`.
+ - can't be successfully built with --enable-executable-profiling (that is, "cabal install cabal-dev" fails if executable-profiling: True is in ~/.cabal/config)
 
 # Feature Ideas
  - support multiple unpacked packages


### PR DESCRIPTION
I couldn't find a real bug tracker, so I've added a line to TODO.md instead. It seems Template Haskell, cabal, and profiling don't work together all that well by default, though I couldn't find anywhere what needed to be done to change the defaults appropriately. http://hackage.haskell.org/trac/hackage/ticket/91 has some details
