### PR TITLE
add Extensions: TemplateHaskell

### DIFF
--- a/cabal-dev.cabal
+++ b/cabal-dev.cabal
@@ -62,6 +62,7 @@ Executable cabal-dev
   HS-Source-Dirs: src
   Main-is: Main.hs
   GHC-Options: -Wall
+  Extensions: TemplateHaskell
 
   if flag(no-cabal-dev)
     Buildable: False


### PR DESCRIPTION
This is needed by Cabal when building a dynamic or profiling executable.
