### PR TITLE
Make ghc-pkg command compatible with GHC HEAD.

### DIFF
--- a/src/Distribution/Dev/GhcPkg.hs
+++ b/src/Distribution/Dev/GhcPkg.hs
@@ -35,8 +35,12 @@ invokeGhcPkg cfg args = do
   s <- initPkgDb v =<< resolveSandbox cfg
   (ghcPkg, _) <- requireProgram v ghcPkgProgram emptyProgramConfiguration
   let extraArgs = case getVersion s of
-                    GHC_6_8_Db _ -> id
-                    _            -> ("--no-user-package-conf":)
+                    GHC_6_8_Db _    -> id
+                    GHC_7_5_Plus_Db -> ("--no-user-package-db":)
+                    _               -> ("--no-user-package-conf":)
+      pkgConfArgName = case getVersion s of
+                         GHC_7_5_Plus_Db -> "--package-db"
+                         _               -> "--package-conf"
 
-  runProgram v ghcPkg $ extraArgs $ "--global" : "--package-conf" : pkgConf s : args
+  runProgram v ghcPkg $ extraArgs $ "--global" : pkgConfArgName : pkgConf s : args
   return CommandOk

--- a/src/Distribution/Dev/InitPkgDb.hs
+++ b/src/Distribution/Dev/InitPkgDb.hs
@@ -42,11 +42,11 @@ initPkgDb v s = do
       s' = setVersion s typ ver
       pth = pkgConf s'
 
-  case typ of
-    GHC_6_12_Db -> do
+  if typ >= GHC_6_12_Db
+    then do
       e <- doesDirectoryExist pth
       unless e $ run v ghcPkg ["init", pth]
-    _ -> do
+    else do
       e <- doesFileExist pth
       unless e $ writeFile pth "[]"
 
@@ -69,5 +69,6 @@ ghcPackageDbType p =
         let typ | v < Version [6, 10] [] = GHC_6_8_Db $ locationPath $
                                            programLocation p
                 | v < Version [6, 12] [] = GHC_6_10_Db
+                | v >= Version [7, 5] [] = GHC_7_5_Plus_Db
                 | otherwise              = GHC_6_12_Db
         return (v, typ)

--- a/src/Distribution/Dev/Sandbox.hs
+++ b/src/Distribution/Dev/Sandbox.hs
@@ -45,7 +45,11 @@ data Sandbox a where
     UnknownVersion :: FilePath -> Sandbox UnknownVersion
     KnownVersion :: FilePath -> PackageDbType -> Version -> Sandbox KnownVersion
 
-data PackageDbType = GHC_6_8_Db FilePath | GHC_6_10_Db | GHC_6_12_Db
+data PackageDbType = GHC_6_8_Db FilePath
+                   | GHC_6_10_Db
+                   | GHC_6_12_Db
+                   | GHC_7_5_Plus_Db
+                   deriving (Eq, Ord, Show)
 
 -- NOTE: GHC < 6.12: compilation warnings about non-exhaustive pattern
 -- matches are spurious (we'd get a type error if we tried to make


### PR DESCRIPTION
In GHC HEAD --no-user-package-conf and --package-conf have been [renamed](https://github.com/ghc/ghc/commit/ca2debb201bf44b518bc06a8d37ca1017ccf390f).
