### PR TITLE
Bug fix for: cabal-dev ghci

### DIFF
--- a/src/FakeGhc.hs
+++ b/src/FakeGhc.hs
@@ -9,8 +9,16 @@ module Main ( main ) where
 
 import System.Environment ( getArgs )
 import Distribution.Dev.GhcArgs ( formatGHCArgs )
+import System.Process ( readProcess )
 
 -- |Take the command line arguments and format them in an
 -- easily-parsed way.
 main :: IO ()
-main = putStr . formatGHCArgs =<< getArgs
+main = do
+  args <- getArgs
+  case args of
+    "--numeric-version":_ -> putStr =<< ghc
+    _                     -> putStr (formatGHCArgs args)
+  where
+  ghc = readProcess "ghc" ["--numeric-version"] []
+


### PR DESCRIPTION
At least on 7.6.1 with cabal 1.16.0.1, I'm seeing a problem with ghci where it complains about `--numeric-version`.

I fixed this by special casing on this argument and delegating it to ghc without snooping. This fixes the problem on my specific versions.
