### PR TITLE
Remove conflicting -O flag when starting ghci

### DIFF
--- a/src/Distribution/Dev/Ghci.hs
+++ b/src/Distribution/Dev/Ghci.hs
@@ -30,7 +30,8 @@ invokeGhci cfg args = do
     Right (buildArgs:_) ->
         do -- Use the arguments that cabal-install passed to GHC to
            -- invoke ghci instead
-          let ghciArgs = "--interactive" : filter (/= "--make") buildArgs
+          let ghciArgs = "--interactive"
+                       : filter (not . (`elem` ["--make", "-O"])) buildArgs
           (ghc, _) <- requireProgram v ghcProgram emptyProgramConfiguration
           runProgram v ghc ghciArgs
           return CommandOk


### PR DESCRIPTION
This helped me around the following problem:

```
$ cabal-dev ghci

<no location info>: 
Failing due to -Werror.

on the commandline:
    Warning: -O conflicts with --interactive; -O ignored.
```
