### PR TITLE
more correct fix for add-source cache invalidation

### DIFF
--- a/src/Distribution/Dev/Sandbox.hs
+++ b/src/Distribution/Dev/Sandbox.hs
@@ -6,6 +6,8 @@ module Distribution.Dev.Sandbox
     , UnknownVersion
     , cabalConf
     , getVersion
+    , indexCache
+    , indexCacheBase
     , indexTar
     , indexTarBase
     , localRepoPath
@@ -121,6 +123,12 @@ resolveSandbox cfg = do
   newSandbox v relSandbox
 
 -- |The name of the cabal-install package index
+indexCacheBase :: FilePath
+indexCacheBase = "00-index.cache"
+
+indexCache :: Sandbox a -> FilePath
+indexCache sb = localRepoPath sb </> indexCacheBase
+
 indexTarBase :: FilePath
 indexTarBase = "00-index.tar"
 

--- a/test/RunTests.hs
+++ b/test/RunTests.hs
@@ -162,14 +162,6 @@ addSourceStaysSandboxed v cabalDev dirName =
       -- with an empty package index
       withCabalDev assertExitsFailure ["install", pkgStr]
 
-      -- XXX: https://github.com/haskell/cabal/issues/1213
-      -- Workaround for a cabal-install bug where the index cache
-      -- may be considered valid when it isn't due to a race condition
-      -- with the modification time.
-      let cacheFile = indexTar sb `replaceExtension` "cache"
-      cacheExists <- doesFileExist cacheFile
-      when cacheExists $ removeFile cacheFile
-
       withCabalDev assertExitsSuccess ["add-source", packageDir]
 
       -- Do the installation. Now this library should be registered


### PR DESCRIPTION
PR #95 was a workaround for invalidation issues in the test suite that assumed the problem was in cabal-install https://github.com/haskell/cabal/issues/1213 - but the problem actually was in cabal-dev. This removes the workaround and hopefully fixes the invalidation issue.
